### PR TITLE
Equine form fix

### DIFF
--- a/membership/forms.py
+++ b/membership/forms.py
@@ -80,6 +80,7 @@ class EquineForm(forms.ModelForm):
         exclude = ('membership_package',
                    'subscription')
         widgets = {
+            'date_resigned': forms.DateInput(attrs={'class': 'form-control datepicker'}),
             'animal_owner': forms.CheckboxInput(attrs={'class': ''}),
             'badge': forms.CheckboxInput(attrs={'class': ''}),
             'expired': forms.DateInput(attrs={'class': 'form-control datepicker'}),

--- a/membership/views.py
+++ b/membership/views.py
@@ -739,12 +739,9 @@ def member_bolton_form(request, title, pk):
             bolton_form.subscription = subscription
             bolton_form.save()
 
-            # redirect to payment form IF card payment selected
-            if subscription.payment_type == 'card_payment':
-                return redirect(
-                    f"member_payment", membership_package.organisation_name, member.id)
-            else:
-                return redirect('membership')
+            return redirect(
+                f"member_payment", membership_package.organisation_name, member.id)
+                
         else:
             return render(request, 'member_bolton_form.html', {'bolton_form': form,
                                                                'membership_package': membership_package,


### PR DESCRIPTION
date_resigned widget added to EquineForm class in forms.py to make the date resigned field within bolton form work. Also, the check within member_bolton_form in views.py to ensure payment method was card payment was removed to allow the save button in the bolton form to go to payment page, as is required.