### PR TITLE
Member join email defect

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1067,6 +1067,20 @@ def update_membership_type(request, title, pk):
             MembershipSubscription.objects.filter(member=member, membership_package=package).update(price=Price.objects.get(stripe_price_id=request.POST.get('membership_type')),
                                                                                                     payment_method=PaymentMethod.objects.get(payment_name=request.POST.get('payment_method'),
                                                                                                                                              membership_package=package))
+            
+            # send confirmation email to new member
+            body = f"""<p>This is a confirmation email for your new Organisation Subscription.
+
+                                        <ul>
+                                        <li>Congratulations, you are now a member of {package.organisation_name} Organisation.</li>
+                                        </ul>
+
+                                        <p>Thank you for choosing Cloud-Lines Memberships and please contact us if you need anything.</p>
+
+                                        """
+            send_email(f"Organisation Confirmation: {package.organisation_name}",
+                    member.user_account.get_full_name(), body, send_to=member.user_account.email)
+            
             return HttpResponse(dumps({'status': "success",
                                        'redirect': True}), content_type='application/json')
         else:

--- a/membership/views.py
+++ b/membership/views.py
@@ -808,18 +808,18 @@ class MemberRegForm(LoginRequiredMixin, FormView):
         self.user.last_name = self.form.cleaned_data['last_name']
         self.user.save()
 
-        # send confirmation email
-        body = f"""<p>This is a confirmation email for your new Organisation Subscription.
+        # # send confirmation email
+        # body = f"""<p>This is a confirmation email for your new Organisation Subscription.
 
-                                       <ul>
-                                       <li>Congratulations, you are now a member of {self.context['membership_package']} Organisation.</li>
-                                       </ul>
+        #                                <ul>
+        #                                <li>Congratulations, you are now a member of {self.context['membership_package']} Organisation.</li>
+        #                                </ul>
 
-                                       <p>Thank you for choosing Cloud-Lines Memberships and please contact us if you need anything.</p>
+        #                                <p>Thank you for choosing Cloud-Lines Memberships and please contact us if you need anything.</p>
 
-                                       """
-        send_email(f"Organisation Confirmation: {self.context['membership_package']}",
-                   self.user.get_full_name(), body, send_to=self.user.email, reply_to=self.user.email)
+        #                                """
+        # send_email(f"Organisation Confirmation: {self.context['membership_package']}",
+        #            self.user.get_full_name(), body, send_to=self.user.email, reply_to=self.user.email)
 
 
 

--- a/membership/views.py
+++ b/membership/views.py
@@ -1086,6 +1086,20 @@ def update_membership_type(request, title, pk):
         else:
             MembershipSubscription.objects.filter(member=member, membership_package=package).update(
                 price=Price.objects.get(stripe_price_id=request.POST.get('membership_type')))
+
+            # send confirmation email to new member
+            body = f"""<p>This is a confirmation email for your new Organisation Subscription.
+
+                                        <ul>
+                                        <li>Congratulations, you are now a member of {package.organisation_name} Organisation.</li>
+                                        </ul>
+
+                                        <p>Thank you for choosing Cloud-Lines Memberships and please contact us if you need anything.</p>
+
+                                        """
+            send_email(f"Organisation Confirmation: {package.organisation_name}",
+                    member.user_account.get_full_name(), body, send_to=member.user_account.email)
+
             return HttpResponse(dumps({'status': "success"}), content_type='application/json')
 
 


### PR DESCRIPTION
Adam recommended only sending emails once the addition of a member is completed successfully, at least for now. So I commented out the email sent in MemberRegForm (as that's just the first step of the process), and added in emails (one for when type is card, and one for when it's not) in update_membership_type, as that is the function I found that was being called after submission of the member-payment form.