### PR TITLE
Fixed card payment bug, now the form is displayed depending on the se…

### DIFF
--- a/membership/templates/member_payment.html
+++ b/membership/templates/member_payment.html
@@ -141,6 +141,13 @@
           return new Promise((resolve) => setTimeout(resolve, time));
         }
 
+        $(document).ready(function() {
+            if ($('.payment_method').value != "Card Payment") {
+                    $('#payment-form').hide();
+                    $("#save-membership").html("Confirm");
+                }
+        });
+
         $('.payment_method').change(function() {
             if (this.value != "Card Payment") {
                 $('#payment-form').fadeOut(400);


### PR DESCRIPTION
When member payment page is accessed, the card payment form is shown even if the specific payment is not selected, the bug was fixed by checking the page, once loaded and if the card payment is not selected the form will be hidden and the button text changed.
