### PR TITLE
Card payment object

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1448,11 +1448,13 @@ def get_member_payments(request, title, pk):
         stripe_payments = stripe.Charge.list(customer=subscription.stripe_id, stripe_account=subscription.membership_package.stripe_acct_id)
         for payment in stripe_payments:
             print(payment)
+            # get the amount as a variable so it can be converted to the correct format to be displayed
+            temp_amount = int(payment['amount'])/100
             payments.append({'action': 'asd',
                             'id': payment['id'],
                             'method': 'Card Payment',
                             'type': 'Card Payment',
-                            'amount': payment['amount'],
+                            'amount': "£%.2f" % temp_amount,
                             'comments': 'asd',
                             'created': 'asd',
                             'gift_aid': 'asd',

--- a/membership/views.py
+++ b/membership/views.py
@@ -1460,8 +1460,11 @@ def get_member_payments(request, title, pk):
                             'gift_aid': 'asd',
                             'gift_aid_percentage': 'asd'})
 
-    if all_payments.count() > 0:
+    # if there are payments in our database, or if it is a stripe subscription
+    if all_payments.count() > 0 or subscription.stripe_id:
         for payment in all_payments:
+            # get the amount as a variable so it can be converted to the correct format to be displayed
+            temp_amount = int(payment.amount)/100
             if payment.gift_aid:
                 giftaid = '<i class="fad fa-check text-success"></i>'
             else:
@@ -1472,7 +1475,7 @@ def get_member_payments(request, title, pk):
                              'id': payment.payment_number,
                              'method': payment.payment_method.payment_name,
                              'type': payment.type,
-                             'amount': payment.amount,
+                             'amount': "£%.2f" % temp_amount,
                              'comments': payment.comments,
                              'created': str(payment.created),
                              'gift_aid': giftaid,

--- a/membership/views.py
+++ b/membership/views.py
@@ -967,26 +967,25 @@ class MemberRegForm(LoginRequiredMixin, FormView):
         try:
             subscription = MembershipSubscription.objects.get(member=self.member, membership_package=self.context['membership_package'])
         except MembershipSubscription.DoesNotExist:
-            # get latest subscription
+            # get latest membership number
             latest_valid_mem_num = MembershipSubscription.objects.last().membership_number
-            # check latest subscription has a valid membership number
+            # check latest membership number is valid
             if latest_valid_mem_num == None or latest_valid_mem_num == '':
-                next_membership_number = 1
                 i = 1
                 # check we haven't gone past the end of the subscriptions
                 if i < MembershipSubscription.objects.all().count():
-                    # get sub before last sub
+                    # get membership number before last before last sub
                     latest_valid_mem_num = MembershipSubscription.objects.all().reverse()[i].membership_number
-                    # go through subscriptions in reverse until we find a valid one
+                    # go through subscription's membership numbers in reverse until we find a valid one
                     while latest_valid_mem_num == None or latest_valid_mem_num == '':
                         i += 1
                         # check we haven't gone past the end of the subscriptions
                         if i < MembershipSubscription.objects.all().count():
                             latest_valid_mem_num = MembershipSubscription.objects.all().reverse()[i].membership_number
-                        # no valid membership numbers
+                        # no valid membership numbers, so set variable to zero
                         else:
                             latest_valid_mem_num = 0
-                # no valid membership numbers
+                # no valid membership numbers, so set variable to zero
                 else:
                     latest_valid_mem_num = 0
             membership_number = int(latest_valid_mem_num) + 1


### PR DESCRIPTION
 Updated MemberRegForm to ensure that a new subscription is given a valid membership number. The main addition was to check that the number to add 1 to was not None or empty string. I used the exact same method in member_payment_form but for payment numbers.
Then I updated get_member_payments to display price amount in the correct format, and to fix the issue where no payments were being displayed if there were stripe payments and no none-stripe payments.