### PR TITLE
Fixed Administer dropdown bug, fully working

### DIFF
--- a/membership/templates/membership-package.html
+++ b/membership/templates/membership-package.html
@@ -148,7 +148,7 @@
                                     </div>
                                 </div>
                                 <h3 class="text-success">Complete Membership Applications</h3>
-                                <div class="table-responsive">
+                                <div class="table-responsive" style="overflow: visible;">
                                     <table id="default_order" class="table table-striped table-bordered display no-wrap" style="width:100%">
                                         <thead>
                                             <tr>

--- a/membership/views.py
+++ b/membership/views.py
@@ -452,7 +452,7 @@ def get_members(request, title):
                             'email': f"{member.user_account.email}",
                             'comments': f"""{sub.comments}<a href="javascript:editComment('{sub.id}');"><i class="fad fa-edit text-success ml-2"></i></a>""",
                             'membership_type': membership_type,
-                            'action': f"""<div class="btn-group dropleft" style="position:fixed;">
+                            'action': f"""<div class="btn-group dropleft">
                                                 <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                                     Administer
                                                 </button>


### PR DESCRIPTION
I have fixed the Administer drop down, by adding overflow: visible to the parent diff, which allows child items to extend over the div.