### PR TITLE
Custom fields visibility

### DIFF
--- a/membership/templates/member_form.html
+++ b/membership/templates/member_form.html
@@ -299,7 +299,11 @@
                                         {% if field_vals.field_type == 'text_field' %}
                                             <div class="col-sm-12 col-lg-6">
                                                 <div class="form-group row">
-                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
+                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}
+                                                        {% if not field_vals.visible %}
+                                                            <br/><small style="font-style: italic;" class="text-danger">Hidden from members</small>
+                                                        {% endif %}
+                                                    </label>
                                                     <div class="col-sm-9">
                                                         <input id="{{ field_vals.id }}" class="form-control" name='{{ field_vals.field_name }}' type="text" value="{{ field_vals.field_value }}">
                                                     </div>
@@ -308,7 +312,11 @@
                                         {% elif field_vals.field_type == 'text_area' %}
                                             <div class="col-sm-12 col-lg-6">
                                                 <div class="form-group row">
-                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
+                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}
+                                                        {% if not field_vals.visible %}
+                                                            <br/><small style="font-style: italic;" class="text-danger">Hidden from members</small>
+                                                        {% endif %}
+                                                    </label>
                                                     <div class="col-sm-9">
                                                         <textarea id="{{ field_vals.id }}" name='{{ field_vals.field_name }}' class="form-control">{{ field_vals.field_value }}</textarea>
                                                     </div>
@@ -317,7 +325,11 @@
                                         {% elif field_vals.field_type == 'date' %}
                                             <div class="col-sm-12 col-lg-6">
                                                 <div class="form-group row">
-                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
+                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}
+                                                        {% if not field_vals.visible %}
+                                                            <br/><small style="font-style: italic;" class="text-danger">Hidden from members</small>
+                                                        {% endif %}
+                                                    </label>
                                                     <div class="col-sm-9">
                                                         <input id="{{ field_vals.id }}" name='{{ field_vals.field_name }}' class="form-control datepicker" type="text" value="{{ field_vals.field_value }}" placeholder="Enter Date">
                                                     </div>

--- a/membership/templates/member_form.html
+++ b/membership/templates/member_form.html
@@ -296,35 +296,33 @@
                                 </div>
                                 {% if custom_fields %}
                                     {% for field_key, field_vals in custom_fields.items %}
-                                        {% if field_vals.visible %}
-                                            {% if field_vals.field_type == 'text_field' %}
-                                                <div class="col-sm-12 col-lg-6">
-                                                    <div class="form-group row">
-                                                        <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
-                                                        <div class="col-sm-9">
-                                                            <input id="{{ field_vals.id }}" class="form-control" name='{{ field_vals.field_name }}' type="text" value="{{ field_vals.field_value }}">
-                                                        </div>
+                                        {% if field_vals.field_type == 'text_field' %}
+                                            <div class="col-sm-12 col-lg-6">
+                                                <div class="form-group row">
+                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
+                                                    <div class="col-sm-9">
+                                                        <input id="{{ field_vals.id }}" class="form-control" name='{{ field_vals.field_name }}' type="text" value="{{ field_vals.field_value }}">
                                                     </div>
                                                 </div>
-                                            {% elif field_vals.field_type == 'text_area' %}
-                                                <div class="col-sm-12 col-lg-6">
-                                                    <div class="form-group row">
-                                                        <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
-                                                        <div class="col-sm-9">
-                                                            <textarea id="{{ field_vals.id }}" name='{{ field_vals.field_name }}' class="form-control">{{ field_vals.field_value }}</textarea>
-                                                        </div>
+                                            </div>
+                                        {% elif field_vals.field_type == 'text_area' %}
+                                            <div class="col-sm-12 col-lg-6">
+                                                <div class="form-group row">
+                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
+                                                    <div class="col-sm-9">
+                                                        <textarea id="{{ field_vals.id }}" name='{{ field_vals.field_name }}' class="form-control">{{ field_vals.field_value }}</textarea>
                                                     </div>
                                                 </div>
-                                            {% elif field_vals.field_type == 'date' %}
-                                                <div class="col-sm-12 col-lg-6">
-                                                    <div class="form-group row">
-                                                        <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
-                                                        <div class="col-sm-9">
-                                                            <input id="{{ field_vals.id }}" name='{{ field_vals.field_name }}' class="form-control datepicker" type="text" value="{{ field_vals.field_value }}" placeholder="Enter Date">
-                                                        </div>
+                                            </div>
+                                        {% elif field_vals.field_type == 'date' %}
+                                            <div class="col-sm-12 col-lg-6">
+                                                <div class="form-group row">
+                                                    <label class="col-sm-3 text-right control-label col-form-label">{{ field_vals.field_name }}</label>
+                                                    <div class="col-sm-9">
+                                                        <input id="{{ field_vals.id }}" name='{{ field_vals.field_name }}' class="form-control datepicker" type="text" value="{{ field_vals.field_value }}" placeholder="Enter Date">
                                                     </div>
                                                 </div>
-                                            {% endif %}
+                                            </div>
                                         {% endif %}
                                     {% endfor %}
                                 {% endif %}

--- a/membership/views.py
+++ b/membership/views.py
@@ -1032,7 +1032,6 @@ def member_reg_form(request, title, pk):
                 if not custom_field['visible']:
                     # remove field
                     del(custom_fields_displayed[key])
-    print(custom_fields_displayed)
 
     if request.method == "GET" and not new_membership:
         # check if user is the same person as the member

--- a/membership/views.py
+++ b/membership/views.py
@@ -1025,13 +1025,14 @@ def member_reg_form(request, title, pk):
     # if user is not owner/admin, remove invisible custom fields
     custom_fields_displayed = custom_fields
     if custom_fields:
-        if request.user == membership_package.owner or request.user in membership_package.admins.all():
+        if request.user != membership_package.owner and request.user not in membership_package.admins.all():
             # iterate through each custom field dictionary
             for key, custom_field in dict(custom_fields_displayed).items():
                 # if field invisible
                 if not custom_field['visible']:
                     # remove field
                     del(custom_fields_displayed[key])
+    print(custom_fields_displayed)
 
     if request.method == "GET" and not new_membership:
         # check if user is the same person as the member
@@ -1210,7 +1211,7 @@ def member_reg_form(request, title, pk):
                                                 'is_price': is_price,
                                                 'is_stripe': is_stripe,
                                                 'member_id': member_id,
-                                                'custom_fields': custom_fields})
+                                                'custom_fields': custom_fields_displayed})
 
 def get_or_create_user(form):
     """

--- a/membership/views.py
+++ b/membership/views.py
@@ -1022,6 +1022,17 @@ def member_reg_form(request, title, pk):
         except JSONDecodeError:
             custom_fields = None
 
+    # if user is not owner/admin, remove invisible custom fields
+    custom_fields_displayed = custom_fields
+    if custom_fields:
+        if request.user == membership_package.owner or request.user in membership_package.admins.all():
+            # iterate through each custom field dictionary
+            for key, custom_field in dict(custom_fields_displayed).items():
+                # if field invisible
+                if not custom_field['visible']:
+                    # remove field
+                    del(custom_fields_displayed[key])
+
     if request.method == "GET" and not new_membership:
         # check if user is the same person as the member
         if member.user_account == request.user:


### PR DESCRIPTION
Updated member_reg_form to pass into member_form.html custom_fields_displayed, which is custom_fields but with invisible custom_fields deleted, if the user is not owner/admin.
Also updated the template to not check whether a custom field is visible before being displayed, as this is already done when necessary.
Also updated template to show a message to owners/admins informing them that the invisible fields are hidden for members.