### PR TITLE
Save and exit

### DIFF
--- a/membership/templates/member_form.html
+++ b/membership/templates/member_form.html
@@ -359,8 +359,14 @@
                             <hr>
                             <div class="card-body">
                                 <div class="form-group mb-0 text-right">
-                                    <button id="save-member" class="btn btn-info waves-effect waves-light">Save</button>
-                                    <a href="{% url 'membership' %}" class="btn btn-dark waves-effect waves-light">Cancel</a>
+                                    {% if request.user == membership_package.owner or request.user in membership_package.admins.all %}
+                                        <button name="exit" id="save-member" class="btn btn-light waves-effect waves-light">Save and Exit</button>    
+                                        <button name="continue" id="save-member" class="btn btn-info waves-effect waves-light">Save and Continue</button>
+                                        <a href="{% url 'membership_package' membership_package.organisation_name %}" class="btn btn-dark waves-effect waves-light">Cancel</a>
+                                    {% else %}
+                                        <button id="save-member" class="btn btn-info waves-effect waves-light">Save</button>
+                                        <a href="{% url 'membership' %}" class="btn btn-dark waves-effect waves-light">Cancel</a>
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>

--- a/membership/views.py
+++ b/membership/views.py
@@ -1041,6 +1041,9 @@ def member_reg_form(request, title, pk):
                     # remove field
                     del(custom_fields_displayed[key])
 
+    # initialise member_id so it can be accessed by code that handles POST request
+    #member_id = None
+
     if request.method == "GET" and not new_membership:
         # check if user is the same person as the member
         if member.user_account == request.user:
@@ -1053,7 +1056,7 @@ def member_reg_form(request, title, pk):
                                'last_name': request.user.last_name}, instance=member)
         else:
             # user is not member, validate user is admin/owner
-            if request.user == membership_package.owner or request.user in membership_package.admins.all:
+            if request.user == membership_package.owner or request.user in membership_package.admins.all():
                 # user is admin/owner editing an existing member
                 member_id = pk
                 form = MemberForm({'email': member.user_account.email,
@@ -1180,14 +1183,43 @@ def member_reg_form(request, title, pk):
                 subscription.custom_fields = dumps(custom_fields)
             subscription.save()
 
-            if membership_package.bolton != 'none' and MembershipPackage.objects.filter(Q(owner=request.user) |
-                                                                        Q(admins=request.user),
-                                                                          organisation_name=membership_package.organisation_name).exists():
-                return redirect(
-                    f"member_bolton_form", membership_package.organisation_name, member.id)
+            # direct user to correct next location
+            # if user is owner/admin...
+            if request.user == membership_package.owner or request.user in membership_package.admins.all():
+                # save and continue
+                if request.POST.get('continue') == '':
+                    if membership_package.bolton != 'none' and MembershipPackage.objects.filter(Q(owner=request.user) |
+                                                                                Q(admins=request.user),
+                                                                                organisation_name=membership_package.organisation_name).exists():
+                        return redirect(
+                            f"member_bolton_form", membership_package.organisation_name, member.id)
+                    else:
+                        return redirect(
+                            f"member_payment", membership_package.organisation_name, member.id)
+                # save and exit to org page
+                elif request.POST.get('exit') == '':
+                    return redirect('membership_package', membership_package.organisation_name)
+                # just in case, continue
+                else:
+                    if membership_package.bolton != 'none' and MembershipPackage.objects.filter(Q(owner=request.user) |
+                                                                                Q(admins=request.user),
+                                                                                organisation_name=membership_package.organisation_name).exists():
+                        return redirect(
+                            f"member_bolton_form", membership_package.organisation_name, member.id)
+                    else:
+                        return redirect(
+                            f"member_payment", membership_package.organisation_name, member.id)
+            # user is a member who has clicked Save, so continue
             else:
-                return redirect(
-                    f"member_payment", membership_package.organisation_name, member.id)
+                if membership_package.bolton != 'none' and MembershipPackage.objects.filter(Q(owner=request.user) |
+                                                                            Q(admins=request.user),
+                                                                            organisation_name=membership_package.organisation_name).exists():
+                    return redirect(
+                        f"member_bolton_form", membership_package.organisation_name, member.id)
+                else:
+                    return redirect(
+                        f"member_payment", membership_package.organisation_name, member.id)
+        
         else:
             # form not valid
             pass


### PR DESCRIPTION
Updated member form template -  If the user is admin/owner, show them the continue, exit and cancel buttons. Otherwise, show them save and cancel as before. For continue and exit buttons I gave them names so in views I could check which button was selected.

In member_reg_form, check where to redirect the user to after the form is submitted. If user is owner/admin, this will depend on whether they selected continue or exit button. Otherwise, treat as all were treated before.