### PR TITLE
Custom field deletion defect

### DIFF
--- a/membership/templates/manage-custom-fields.html
+++ b/membership/templates/manage-custom-fields.html
@@ -162,7 +162,7 @@
                                         <div class="modal-footer">
                                             <button type="button" class="btn btn-light"
                                                 data-dismiss="modal">Close</button>
-                                            <button type="button" class="btn btn-outline-light" onclick="deleteField()">Confirm Deletion</button>
+                                            <button type="button" class="btn btn-outline-light" onclick="deleteField({{ forloop.counter }})">Confirm Deletion</button>
                                         </div>
                                     </div><!-- /.modal-content -->
                                 </div><!-- /.modal-dialog -->
@@ -209,17 +209,17 @@
                                 $("#delTypeForm{{ forloop.counter }}").click(function(){
                                     $('#delete-field-modal{{ forloop.counter }}').modal('toggle');
                                 });
-                                function deleteField() {
-                                    $('#delete-field-modal{{ forloop.counter }}').modal('toggle');
-                                    $("#type{{ forloop.counter }}").val('delete')
-                                    $('#delTypeForm{{ forloop.counter }}').html('<i class="fad fa-spinner-third fa-spin"></i> Deleting')
+                                function deleteField(forloop_counter) {
+                                    $('#delete-field-modal' + forloop_counter).modal('toggle');
+                                    $('#type' + forloop_counter).val('delete')
+                                    $('#delTypeForm' + forloop_counter).html('<i class="fad fa-spinner-third fa-spin"></i> Deleting')
                                     $.ajax({
                                         url: '{% url 'manage_custom_fields' membership_package.organisation_name %}',
                                         enctype: 'multipart/form-data',
                                         type: 'POST',
                                         dataType: 'text',
                                         headers: {'X-CSRFToken': '{{ csrf_token }}'},
-                                        data: $('#editCustomFieldForm{{ forloop.counter }}').serialize(),
+                                        data: $('#editCustomFieldForm' + forloop_counter).serialize(),
                                         beforeSend: function() {
                                         },
                                         success: function(data) {
@@ -227,7 +227,7 @@
                                             if (result['status'] == "fail") {
                                                 errorMsg(result['message']);
                                             } else {
-                                                $('#editCustomFieldForm{{ forloop.counter }}').addClass('d-none')
+                                                $('#editCustomFieldForm' + forloop_counter).addClass('d-none')
                                                 infoMsg(result.message);
                                                 location.reload();
                                             }

--- a/membership/templates/manage-custom-fields.html
+++ b/membership/templates/manage-custom-fields.html
@@ -229,6 +229,7 @@
                                             } else {
                                                 $('#editCustomFieldForm{{ forloop.counter }}').addClass('d-none')
                                                 infoMsg(result.message);
+                                                location.reload();
                                             }
                                         },
                                         error: function(jqXHR, textStatus, errorThrown){

--- a/membership/templates/manage-custom-fields.html
+++ b/membership/templates/manage-custom-fields.html
@@ -229,7 +229,6 @@
                                             } else {
                                                 $('#editCustomFieldForm' + forloop_counter).addClass('d-none')
                                                 infoMsg(result.message);
-                                                location.reload();
                                             }
                                         },
                                         error: function(jqXHR, textStatus, errorThrown){

--- a/membership/templates/manage-custom-fields.html
+++ b/membership/templates/manage-custom-fields.html
@@ -182,6 +182,8 @@
                                     $('#saveTypeForm{{ forloop.counter }}').removeClass('d-none')
                                 });
                                 $("#saveTypeForm{{ forloop.counter }}").click(function(){
+                                    $('.btn-danger').prop('disabled', true);
+                                    $('.btn-success').prop('disabled', true);
                                     $('#saveTypeForm{{ forloop.counter }}').html('<i class="fad fa-spinner-third fa-spin"></i> Updating')
                                     $.ajax({
                                         url: '{% url 'manage_custom_fields' membership_package.organisation_name %}',
@@ -204,6 +206,8 @@
                                         error: function(jqXHR, textStatus, errorThrown){
                                         }
                                     });
+                                    $('.btn-danger').prop('disabled', false);
+                                    $('.btn-success').prop('disabled', false);
                                 });
 
                                 $("#delTypeForm{{ forloop.counter }}").click(function(){

--- a/membership/templates/manage-custom-fields.html
+++ b/membership/templates/manage-custom-fields.html
@@ -210,6 +210,8 @@
                                     $('#delete-field-modal{{ forloop.counter }}').modal('toggle');
                                 });
                                 function deleteField(forloop_counter) {
+                                    $('.btn-danger').prop('disabled', true);
+                                    $('.btn-success').prop('disabled', true);
                                     $('#delete-field-modal' + forloop_counter).modal('toggle');
                                     $('#type' + forloop_counter).val('delete')
                                     $('#delTypeForm' + forloop_counter).html('<i class="fad fa-spinner-third fa-spin"></i> Deleting')
@@ -234,6 +236,8 @@
                                         error: function(jqXHR, textStatus, errorThrown){
                                         }
                                     });
+                                    $('.btn-danger').prop('disabled', false);
+                                    $('.btn-success').prop('disabled', false);
                                 }
                             </script>
                         {% endfor %}

--- a/membership/templates/manage-custom-fields.html
+++ b/membership/templates/manage-custom-fields.html
@@ -314,6 +314,8 @@
         });
 
         function addNewField() {
+            $('.btn-danger').prop('disabled', true);
+            $('.btn-success').prop('disabled', true);
             $.ajax({
                 url: '{% url 'manage_custom_fields' membership_package.organisation_name %}',
                 enctype: 'multipart/form-data',
@@ -336,6 +338,8 @@
                 error: function(jqXHR, textStatus, errorThrown){
                 }
             });
+            $('.btn-danger').prop('disabled', false);
+            $('.btn-success').prop('disabled', false);
         }
     </script>
     <script src="{% static 'assets/libs/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js' %}"></script>


### PR DESCRIPTION
I think within the deleteField function, forloop.counter has the value of the latest iteration. e.g. if there are 4 custom fields displayed, the value of forloop.counter within deleteField() is 4. For this reason, only the final custom field was ever being deleted. I got around this by passing in the value of forloop.counter when it's called, and using that value as the variable forloop_counter inside the function.

To this branch, to avoid merge conflicts, I also pushed up the disabling of buttons while changes are being made to any custom fields (delete, edit, add new).