### PR TITLE
No visible types

### DIFF
--- a/membership/templates/member_form.html
+++ b/membership/templates/member_form.html
@@ -42,7 +42,7 @@
         <div class="col-12">
             <div class="card">
                 <!-- Validate that membership package has been set up with stripe and has at least one membership type -->
-                {% if ((is_stripe and is_price_active) and (request.user == membership_package.owner or request.user in membership_package.admins.all)) or (is_stripe and is_price_active_visible) %}
+                {% if is_stripe and is_price_active and request.user == membership_package.owner or request.user in membership_package.admins.all or is_stripe and is_price_active_visible %}
                     <div class="card-body">
                         <h4 class="card-title">Member Form</h4>
                         <h6 class="card-subtitle">Fill out the form below to add a new member to your organisation.</h6>

--- a/membership/templates/member_form.html
+++ b/membership/templates/member_form.html
@@ -42,7 +42,7 @@
         <div class="col-12">
             <div class="card">
                 <!-- Validate that membership package has been set up with stripe and has at least one membership type -->
-                {% if is_stripe and is_price %}
+                {% if is_stripe and is_price_active %}
                     <div class="card-body">
                         <h4 class="card-title">Member Form</h4>
                         <h6 class="card-subtitle">Fill out the form below to add a new member to your organisation.</h6>
@@ -361,7 +361,7 @@
                                 <p>To allow members to be added, you can manage membership types from the <a href="{% url 'membership_package' membership_package.organisation_name %}">Membership</a> page.</p>
                             </div>
                         <!-- stripe not set up -->
-                        {% elif is_price %}
+                        {% elif is_price_active %}
                             <div class="card-body">
                                 <h4 class="card-title">Membership Package Not Ready</h4>
                                 <p>This membership package does not have stripe set up.</p>

--- a/membership/templates/member_form.html
+++ b/membership/templates/member_form.html
@@ -42,7 +42,7 @@
         <div class="col-12">
             <div class="card">
                 <!-- Validate that membership package has been set up with stripe and has at least one membership type -->
-                {% if is_stripe and is_price_active %}
+                {% if ((is_stripe and is_price_active) and (request.user == membership_package.owner or request.user in membership_package.admins.all)) or (is_stripe and is_price_active_visible) %}
                     <div class="card-body">
                         <h4 class="card-title">Member Form</h4>
                         <h6 class="card-subtitle">Fill out the form below to add a new member to your organisation.</h6>

--- a/membership/views.py
+++ b/membership/views.py
@@ -1257,6 +1257,10 @@ def member_reg_form(request, title, pk):
         if price.active:
             is_price_active = True
             break
+    for price in prices:
+        if price.active and price.visible:
+            is_price_active_visible = True
+            break
     # check stripe has been set up
     stripe.api_key = get_stripe_secret_key(request)
     is_stripe = False

--- a/membership/views.py
+++ b/membership/views.py
@@ -1246,7 +1246,7 @@ def member_reg_form(request, title, pk):
         else:
             # form not valid
             pass
-    # check membership type exists
+    # check there is a membership type which is active
     is_price_active = False
     prices = None
     try:
@@ -1257,6 +1257,8 @@ def member_reg_form(request, title, pk):
         if price.active:
             is_price_active = True
             break
+    # check there is a membership type which is both active and visible
+    is_price_active_visible = False
     for price in prices:
         if price.active and price.visible:
             is_price_active_visible = True

--- a/membership/views.py
+++ b/membership/views.py
@@ -1247,7 +1247,7 @@ def member_reg_form(request, title, pk):
             # form not valid
             pass
     # check membership type exists
-    is_price = False
+    is_price_active = False
     prices = None
     try:
         prices = Price.objects.filter(membership_package=membership_package)
@@ -1255,7 +1255,7 @@ def member_reg_form(request, title, pk):
         pass
     for price in prices:
         if price.active:
-            is_price = True
+            is_price_active = True
             break
     # check stripe has been set up
     stripe.api_key = get_stripe_secret_key(request)
@@ -1271,7 +1271,7 @@ def member_reg_form(request, title, pk):
     return render(request, 'member_form.html', {'user_form_fields': user_form_fields,
                                                 'form': form,
                                                 'membership_package': membership_package,
-                                                'is_price': is_price,
+                                                'is_price_active': is_price_active,
                                                 'is_stripe': is_stripe,
                                                 'member_id': member_id,
                                                 'custom_fields': custom_fields_displayed})

--- a/membership/views.py
+++ b/membership/views.py
@@ -1276,6 +1276,7 @@ def member_reg_form(request, title, pk):
                                                 'form': form,
                                                 'membership_package': membership_package,
                                                 'is_price_active': is_price_active,
+                                                'is_price_active_visible': is_price_active_visible,
                                                 'is_stripe': is_stripe,
                                                 'member_id': member_id,
                                                 'custom_fields': custom_fields_displayed})


### PR DESCRIPTION
Created a new variable which is true if there are any membership types which are both active and visible. I used this variable within the member form template to ensure that members aren't allowed through if there are no visible types. This fixed the defect where a member could get all the way to the payment page and not have any available membership types to select, and so could not progress.