### PR TITLE
Type status defect

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -552,7 +552,7 @@ def get_members(request, title):
     if all_members.count() > 0:
         for member in all_members:
             # get membership type
-            for sub in member.subscription.all():
+            for sub in member.subscription.filter(membership_package=membership_package):
                 if sub.membership_package == membership_package:
                     try:
                         membership_type = f"""<span class="badge py-1 badge-info">{sub.price.nickname}</span>"""

--- a/membership/views.py
+++ b/membership/views.py
@@ -582,7 +582,7 @@ def get_members(request, title):
                     membership_status = ""
 
             # buttons!
-            for sub in member.subscription.all():
+            for sub in member.subscription.filter(membership_package=membership_package):
                 if sub.membership_package == membership_package:
                     if sub.payment_method or sub.stripe_subscription_id:
                         pass


### PR DESCRIPTION
When iterating through subscriptions to get membership type, instead of iterating through them all, it now just iterates through the subscriptions for this membership package. This fixed the issue of type and status not being displayed, because the body of the else statement was being ran, and made type and status empty string; this now doesn't happen.