### PR TITLE
Status defect

### DIFF
--- a/membership/templates/membership-package.html
+++ b/membership/templates/membership-package.html
@@ -432,7 +432,7 @@
                         }
 
                         $('#update-membership-status-modal').modal('show');
-                        $('#updateStatusUrl').attr("href", "/membership/update-membership-status/"+memberId+"/"+status);
+                        $('#updateStatusUrl').attr("href", "/membership/update-membership-status/"+memberId+"/"+status+"/{{ membership_package.organisation_name }}");
 
                         $(this).bootstrapSwitch('toggleState', true, true);
 

--- a/membership/urls.py
+++ b/membership/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     path('member-profile/<int:pk>', views.MemberProfileView.as_view(), name="member_profile"),
     path('delete-membership-package/<str:title>', views.delete_membership_package, name="delete_membership_package"),
     path('remove-member/<str:title>/<int:pk>', views.remove_member, name="remove_member"),
-    path('update-membership-status/<int:pk>/<str:status>', views.update_membership_status, name="update_membership_status"),
+    path('update-membership-status/<int:pk>/<str:status>/<str:title>', views.update_membership_status, name="update_membership_status"),
     path('update_user/<int:pk>', views.update_user, name='update_user'),
     path('payment-reminder/<str:title>/<int:pk>', views.payment_reminder, name='payment_reminder'),
 ]

--- a/membership/views.py
+++ b/membership/views.py
@@ -578,9 +578,10 @@ def get_members_detailed(request, title):
     return HttpResponse(dumps(complete_data))
 
 
-def update_membership_status(request, pk, status):
+def update_membership_status(request, pk, status, title):
     member = Member.objects.get(id=pk)
-    subscription = member.subscription.get(member=member)
+    membership_package = MembershipPackage.objects.get(organisation_name=title)
+    subscription = member.subscription.get(member=member, membership_package=membership_package)
 
     subscription.active = status
     subscription.save()

--- a/membership/views.py
+++ b/membership/views.py
@@ -585,7 +585,7 @@ def update_membership_status(request, pk, status, title):
 
     subscription.active = status
     subscription.save()
-    return HttpResponseRedirect('/membership')
+    return HttpResponseRedirect('/membership/org/' + membership_package.organisation_name)
 
 
 def get_members(request, title):


### PR DESCRIPTION
Included title in update_membership_status so multiple subscriptions aren't returned when the member has multiple subscriptions.

Also redirect to org page when status is changed, to solve the defect Adam found where he was getting redirected to dashboard after changing membership status.