### PR TITLE
Added a line of code to hide the modal if the result is an error. Thi…

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -561,6 +561,7 @@
                     // Inform the customer that there was an error.
                     var errorElement = document.getElementById('donation-card-errors');
                     errorElement.textContent = result.error.message;
+                    $('#donation-overlay-spinner').modal('hide');
                 } else {
                     // Send the token to your server.
                     donationStripeTokenHandler(result.token);


### PR DESCRIPTION
Added a line of code to hide the modal if the result is an error. This fixes a defect found where the spinner wasn't hiding if the user didn't input a card number in the donation form.