### PR TITLE
Email in use defects

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1233,7 +1233,7 @@ def member_reg_form(request, title, pk):
                                           country=form.cleaned_data['country'],
                                           postcode=form.cleaned_data['postcode'],
                                           contact_number=form.cleaned_data['contact_number'])
-                    pass
+                    
                 except User.DoesNotExist:
                     user = User.objects.create(first_name=form.cleaned_data['first_name'],
                                         last_name=form.cleaned_data['last_name'],
@@ -1251,7 +1251,7 @@ def member_reg_form(request, title, pk):
                                           country=form.cleaned_data['country'],
                                           postcode=form.cleaned_data['postcode'],
                                           contact_number=form.cleaned_data['contact_number'])
-                    pass
+                    
             elif pk != 0 and request.user == membership_package.owner or request.user in membership_package.admins.all():
                 # edit member
                 # validate email not already in use

--- a/membership/views.py
+++ b/membership/views.py
@@ -1265,17 +1265,27 @@ def member_reg_form(request, title, pk):
                 finally:
                     member.user_account.first_name = form.cleaned_data['first_name']
                     member.user_account.last_name = form.cleaned_data['last_name']
-                    Member.objects.filter(pk=pk).update(title=form.cleaned_data['title'],
-                                                        company=form.cleaned_data['company'],
-                                                        address_line_1=form.cleaned_data['address_line_1'],
-                                                        address_line_2=form.cleaned_data['address_line_2'],
-                                                        town=form.cleaned_data['town'],
-                                                        county=form.cleaned_data['county'],
-                                                        country=form.cleaned_data['country'],
-                                                        postcode=form.cleaned_data['postcode'],
-                                                        contact_number=form.cleaned_data['contact_number']
-                                                        )
+                    # Member.objects.filter(pk=pk).update(title=form.cleaned_data['title'],
+                    #                                     company=form.cleaned_data['company'],
+                    #                                     address_line_1=form.cleaned_data['address_line_1'],
+                    #                                     address_line_2=form.cleaned_data['address_line_2'],
+                    #                                     town=form.cleaned_data['town'],
+                    #                                     county=form.cleaned_data['county'],
+                    #                                     country=form.cleaned_data['country'],
+                    #                                     postcode=form.cleaned_data['postcode'],
+                    #                                     contact_number=form.cleaned_data['contact_number']
+                    #                                     )
+                    member.title=form.cleaned_data['title']
+                    member.company=form.cleaned_data['company']
+                    member.address_line_1=form.cleaned_data['address_line_1']
+                    member.address_line_2=form.cleaned_data['address_line_2']
+                    member.town=form.cleaned_data['town']
+                    member.county=form.cleaned_data['county']
+                    member.country=form.cleaned_data['country']
+                    member.postcode=form.cleaned_data['postcode']
+                    member.contact_number=form.cleaned_data['contact_number']
                     member.save()
+                    
             else:
                 # new membership request but user is not admin/owner tut tut
                 redirect('dashboard')

--- a/membership/views.py
+++ b/membership/views.py
@@ -1218,9 +1218,8 @@ def member_reg_form(request, title, pk):
                 # new member
                 # validate user not already a member of package
                 try:
-                    if MembershipSubscription.objects.filter(member=Member.objects.get(
-                            user_account=User.objects.get(email=form.cleaned_data['email'])),
-                            membership_package=membership_package).exists():
+                    member = Member.objects.get(user_account=User.objects.get(email=form.cleaned_data['email']))
+                    if MembershipSubscription.objects.filter(member=member, membership_package=membership_package).exists():
                         form.add_error('email', f"This email address is already in use for "
                                                 f"{membership_package.organisation_name}.")
                 except Member.DoesNotExist:

--- a/membership/views.py
+++ b/membership/views.py
@@ -1256,7 +1256,8 @@ def member_reg_form(request, title, pk):
                 # edit member
                 # validate email not already in use
                 try:
-                    if Member.objects.filter(user_account=User.objects.get(email=form.cleaned_data['email'])).exclude(id=member.id).exists():
+                    if MembershipSubscription.objects.filter(member=Member.objects.get(user_account=User.objects.get(
+                            email=form.cleaned_data['email'])), membership_package=membership_package).exclude(member=member).exists():
                         form.add_error('email',
                                        f"This email address is already in use for {membership_package.organisation_name}.")
                 except User.DoesNotExist:

--- a/membership/views.py
+++ b/membership/views.py
@@ -1256,10 +1256,15 @@ def member_reg_form(request, title, pk):
                 # edit member
                 # validate email not already in use
                 try:
+                    # if email is in use for this membership package, add an error to the form
                     if MembershipSubscription.objects.filter(member=Member.objects.get(user_account=User.objects.get(
                             email=form.cleaned_data['email'])), membership_package=membership_package).exclude(member=member).exists():
                         form.add_error('email',
                                        f"This email address is already in use for {membership_package.organisation_name}.")
+                    # email is in use for a different package, so it for the member
+                    else:
+                        member.user_account.email = form.cleaned_data['email']
+                # email not in use, so save it for the member
                 except User.DoesNotExist:
                     member.user_account.email = form.cleaned_data['email']
                 finally:
@@ -1275,16 +1280,17 @@ def member_reg_form(request, title, pk):
                     #                                     postcode=form.cleaned_data['postcode'],
                     #                                     contact_number=form.cleaned_data['contact_number']
                     #                                     )
-                    member.title=form.cleaned_data['title']
-                    member.company=form.cleaned_data['company']
-                    member.address_line_1=form.cleaned_data['address_line_1']
-                    member.address_line_2=form.cleaned_data['address_line_2']
-                    member.town=form.cleaned_data['town']
-                    member.county=form.cleaned_data['county']
-                    member.country=form.cleaned_data['country']
-                    member.postcode=form.cleaned_data['postcode']
-                    member.contact_number=form.cleaned_data['contact_number']
+                    member.title = form.cleaned_data['title']
+                    member.company = form.cleaned_data['company']
+                    member.address_line_1 = form.cleaned_data['address_line_1']
+                    member.address_line_2 = form.cleaned_data['address_line_2']
+                    member.town = form.cleaned_data['town']
+                    member.county = form.cleaned_data['county']
+                    member.country = form.cleaned_data['country']
+                    member.postcode = form.cleaned_data['postcode']
+                    member.contact_number = form.cleaned_data['contact_number']
                     member.save()
+                    member.user_account.save()
                     
             else:
                 # new membership request but user is not admin/owner tut tut


### PR DESCRIPTION
I was getting the UnboundLocalError again (member used before declared), this time when trying to add a member using an existing email. The try wouldn't fail because the member and user existed, but the body if the if statement wouldn't get called to add an error to the form because a member for that package didn't exist - also, the excepts didn't get called which create a member. So, to solve it, within the try, I set member to the member with the email given in the form, and then use that in the if statement.

From edit member, I couldn't use the email address of a member from another organisation, so I made it so that you could. Let me know if that shouldn't be allowed. The thinking was that email address only has to be unique for each package.

I wasn't able to successfully edit a member. I commented out the update function (didn't want to completely remove it yet) and set each attribute manually. Also, I needed to save member.user_account separately to member. Also, email wasn't being changed if member exists in a different package, as the try worked so the except wasn't called. I just added an else in the try and set it there.