### PR TITLE
changes made to member_reg_form in 2 places to not allow an email to …

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1219,9 +1219,8 @@ def member_reg_form(request, title, pk):
                 # validate user not already a member of package
                 try:
                     member = Member.objects.get(user_account=User.objects.get(email=form.cleaned_data['email']))
-                    if MembershipSubscription.objects.filter(member=member, membership_package=membership_package).exists():
-                        form.add_error('email', f"This email address is already in use for "
-                                                f"{membership_package.organisation_name}.")
+                    if MembershipSubscription.objects.filter(member=member).exists():
+                        form.add_error('email', f"This email address is already in use.")
                 except Member.DoesNotExist:
                     member = Member.objects.create(user_account=User.objects.get(email=form.cleaned_data['email']),
                                           title=form.cleaned_data['title'],
@@ -1256,11 +1255,11 @@ def member_reg_form(request, title, pk):
                 # edit member
                 # validate email not already in use
                 try:
-                    # if email is in use for this membership package, add an error to the form
+                    # if email is in use, add an error to the form
                     if MembershipSubscription.objects.filter(member=Member.objects.get(user_account=User.objects.get(
-                            email=form.cleaned_data['email'])), membership_package=membership_package).exclude(member=member).exists():
+                            email=form.cleaned_data['email']))).exclude(member=member).exists():
                         form.add_error('email',
-                                       f"This email address is already in use for {membership_package.organisation_name}.")
+                                       f"This email address is already in use.")
                     # email is in use for a different package, so it for the member
                     else:
                         member.user_account.email = form.cleaned_data['email']


### PR DESCRIPTION
Due to allowing more than 1 member to have a user account with the same email, I was getting multiple objects returned on the get methods that get User with the email address given, because I already had multiple members with the email address I was trying to use. I then realised that I didn't think we should be allowing multiple members to have the same email address - for example, what if one member using the email address was paying their bills, the other wasn't, and the owner sent a payment reminder intending it to be for the one not paying their bills, but it got sent to the one that was paying their bills too.
If you disagree and think that we should allow more than one member to have the same email address, don't merge this branch. And, there will need to be a change to 2 places in member_reg_form so that multiple objects are not returned when attempting to get the user with the given email.

changes made to member_reg_form in 2 places to not allow an email to be used if it is used by any other users, regardless of what their membership package is