### PR TITLE
Check if it's a stripe customer before checking if it's a stripe subs…

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1689,15 +1689,18 @@ class MemberProfileView(MembershipBase):
         context['subscriptions'] = {}
         stripe.api_key = get_stripe_secret_key(self.request)
         for subscription in context['member'].subscription.all():
-            if subscription.stripe_subscription_id:
+            # if it's a stripe customer
+            if subscription.stripe_id:
                 context['subscriptions'][subscription.id] = {}
-                context['subscriptions'][subscription.id]['subscription'] = stripe.Subscription.retrieve(subscription.stripe_subscription_id,
-                                                                       stripe_account=subscription.membership_package.stripe_acct_id)
-
                 context['subscriptions'][subscription.id]['customer'] = stripe.Customer.retrieve(subscription.stripe_id,
                                                                stripe_account=subscription.membership_package.stripe_acct_id)
                 context['subscriptions'][subscription.id]['payments'] = stripe.Charge.list(customer=subscription.stripe_id,
                                                                stripe_account=subscription.membership_package.stripe_acct_id)
+                # if it's a stripe subscription
+                if subscription.stripe_subscription_id:
+                    context['subscriptions'][subscription.id]['subscription'] = stripe.Subscription.retrieve(subscription.stripe_subscription_id,
+                                                                        stripe_account=subscription.membership_package.stripe_acct_id)
+
         return context
 
 


### PR DESCRIPTION
If it's a stripe customer but not a stripe subscription (happens when membership type is changed from stripe to none stripe) the payments tab of profile doesn't show any stripe payments, even though they exist. I got around this by first checking if it's a stripe customer, then adding the customer and customer's payments to context in MemberProfileView, before checking if it's a stripe subscription and then adding the subscription to context.