### PR TITLE
Manage pages layout

### DIFF
--- a/membership/templates/manage-admins.html
+++ b/membership/templates/manage-admins.html
@@ -43,11 +43,11 @@
         <div class="col-lg-4 col-xlg-3 col-md-5">
             <div class="card">
                 <div class="card-body">
-                    <center>{% include 'org_menu.html' %}</center>
-                    <center class="mt-4">
+                    <div class="text-center">{% include 'org_menu.html' %}</div>
+                    <div class="mt-4 text-center">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>
-                    </center>
+                    </div>
                 </div>
                 <hr>
                 <div class="card-body">

--- a/membership/templates/manage-admins.html
+++ b/membership/templates/manage-admins.html
@@ -43,7 +43,7 @@
         <div class="col-lg-4 col-xlg-3 col-md-5">
             <div class="card">
                 <div class="card-body">
-                    <span class="">{% include 'org_menu.html' %}</span>
+                    <center>{% include 'org_menu.html' %}</center>
                     <center class="mt-4">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>

--- a/membership/templates/manage-custom-fields.html
+++ b/membership/templates/manage-custom-fields.html
@@ -46,11 +46,11 @@
         <div class="col-lg-4 col-xlg-3">
             <div class="card">
                 <div class="card-body">
-                    <center>{% include 'org_menu.html' %}</center>
-                    <center class="mt-4">
+                    <div class="text-center">{% include 'org_menu.html' %}</div>
+                    <div class="mt-4 text-center">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>
-                    </center>
+                    </div>
                 </div>
                 <hr>
                 <div class="card-body">

--- a/membership/templates/manage-custom-fields.html
+++ b/membership/templates/manage-custom-fields.html
@@ -46,7 +46,7 @@
         <div class="col-lg-4 col-xlg-3">
             <div class="card">
                 <div class="card-body">
-                    <span class="float-right">{% include 'org_menu.html' %}</span>
+                    <center>{% include 'org_menu.html' %}</center>
                     <center class="mt-4">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>

--- a/membership/templates/manage-membership-types.html
+++ b/membership/templates/manage-membership-types.html
@@ -44,11 +44,11 @@
         <div class="col-lg-4 col-xlg-3 col-md-5">
             <div class="card">
                 <div class="card-body">
-                    <center>{% include 'org_menu.html' %}</center>
-                    <center class="mt-4">
+                    <div class="text-center">{% include 'org_menu.html' %}</div>
+                    <div class="mt-4 text-center">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>
-                    </center>
+                    </div>
                 </div>
                 <hr>
                 <div class="card-body">

--- a/membership/templates/manage-membership-types.html
+++ b/membership/templates/manage-membership-types.html
@@ -44,7 +44,7 @@
         <div class="col-lg-4 col-xlg-3 col-md-5">
             <div class="card">
                 <div class="card-body">
-                    <span class="float-right">{% include 'org_menu.html' %}</span>
+                    <center>{% include 'org_menu.html' %}</center>
                     <center class="mt-4">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>

--- a/membership/templates/manage-payment-methods.html
+++ b/membership/templates/manage-payment-methods.html
@@ -44,11 +44,11 @@
         <div class="col-lg-4 col-xlg-3 col-md-5">
             <div class="card">
                 <div class="card-body">
-                    <center>{% include 'org_menu.html' %}</center>
-                    <center class="mt-4">
+                    <div class="text-center">{% include 'org_menu.html' %}</div>
+                    <div class="mt-4 text-center">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>
-                    </center>
+                    </div>
                 </div>
                 <hr>
                 <div class="card-body">

--- a/membership/templates/manage-payment-methods.html
+++ b/membership/templates/manage-payment-methods.html
@@ -44,7 +44,7 @@
         <div class="col-lg-4 col-xlg-3 col-md-5">
             <div class="card">
                 <div class="card-body">
-                    <span class="float-right">{% include 'org_menu.html' %}</span>
+                    <center>{% include 'org_menu.html' %}</center>
                     <center class="mt-4">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>

--- a/membership/templates/manage_payment_reminder.html
+++ b/membership/templates/manage_payment_reminder.html
@@ -46,11 +46,11 @@
         <div class="col-lg-4 col-xlg-3">
             <div class="card">
                 <div class="card-body">
-                    <center>{% include 'org_menu.html' %}</center>
-                    <center class="mt-4">
+                    <div class="text-center">{% include 'org_menu.html' %}</div>
+                    <div class="mt-4 text-center">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>
-                    </center>
+                    </div>
                 </div>
                 <hr>
                 <div class="card-body">

--- a/membership/templates/manage_payment_reminder.html
+++ b/membership/templates/manage_payment_reminder.html
@@ -46,7 +46,7 @@
         <div class="col-lg-4 col-xlg-3">
             <div class="card">
                 <div class="card-body">
-                    <span class="float-right">{% include 'org_menu.html' %}</span>
+                    <center>{% include 'org_menu.html' %}</center>
                     <center class="mt-4">
                         <h4 class="card-title mt-2">{{ membership_package.organisation_name }}</h4>
                         <h6 class="card-title mt-2">Owner: {{ membership_package.owner.get_full_name }}</h6>


### PR DESCRIPTION
For each of the left hand columns of the manage pages, I made it look neater just by putting the include of the buttons in a <center> tag instead of the <span class="float-right"> it was in before. So now the buttons are above the detailing of org name and org owner, and are central.