### PR TITLE
Remove member defect

### DIFF
--- a/membership/tabledata.py
+++ b/membership/tabledata.py
@@ -351,7 +351,7 @@ def get_members(request, title):
                     payment_reminder_button = f"""<a href="{reverse('payment_reminder', kwargs={'title': membership_package.organisation_name,
                                                                                         'pk': subscription.member.id})}" class="dropdown-item" data-toggle="tooltip" title="Recently Sent"><i class="fad fa-envelope-open-dollar mr-2"></i><i>Payment Reminder</i></a>"""
 
-            remove_member_button = f"""<a href="javascript:removeMember({ subscription.member.id }, show_hide_col);" value="{ subscription.member.id }" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>"""
+            remove_member_button = f"""<a href="javascript:removeMember({ subscription.member.id }, 'show_hide_col');" value="{ subscription.member.id }" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>"""
 
             # make the new lines in the comments show in the table
             comments = subscription.comments.replace('\n', '<br/>')

--- a/membership/tabledata.py
+++ b/membership/tabledata.py
@@ -351,7 +351,7 @@ def get_members(request, title):
                     payment_reminder_button = f"""<a href="{reverse('payment_reminder', kwargs={'title': membership_package.organisation_name,
                                                                                         'pk': subscription.member.id})}" class="dropdown-item" data-toggle="tooltip" title="Recently Sent"><i class="fad fa-envelope-open-dollar mr-2"></i><i>Payment Reminder</i></a>"""
 
-            remove_member_button = f"""<a href="javascript:removeMember({ subscription.member.id });" value="{ subscription.member.id }" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>"""
+            remove_member_button = f"""<a href="javascript:removeMember({ subscription.member.id }, show_hide_col);" value="{ subscription.member.id }" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>"""
 
             # make the new lines in the comments show in the table
             comments = subscription.comments.replace('\n', '<br/>')

--- a/membership/tabledata.py
+++ b/membership/tabledata.py
@@ -145,7 +145,7 @@ def get_members_detailed(request, title):
                     payment_reminder_button = f"""<a href="{reverse('payment_reminder', kwargs={'title': membership_package.organisation_name,
                                                                                         'pk': subscription.member.id})}" class="dropdown-item" data-toggle="tooltip" title="Recently Sent"><i class="fad fa-envelope-open-dollar mr-2"></i><i>Payment Reminder</i></a>"""
 
-            remove_member_button = f"""<a href="javascript:removeMember({subscription.member.id});" value="{subscription.member.id}" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>"""
+            remove_member_button = f"""<a href="javascript:removeMember({subscription.member.id}, 'show_hide_col');" value="{subscription.member.id}" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>"""
 
             # create a string for address to avoid including extra line breaks
             address_string = ""

--- a/membership/templates/members_detailed.html
+++ b/membership/templates/members_detailed.html
@@ -281,9 +281,10 @@
 </script>
 <!-- remove member -->
 <script>
-    var removeMember = function (user_id) {
+    var removeMember = function (user_id, table_id) {
         $('#remove-member-modal').modal('show');
         $('#user-id').val(user_id);
+        $('#table-id').val(table_id);
     }
 </script>
 {% endblock %}

--- a/membership/templates/membership-package.html
+++ b/membership/templates/membership-package.html
@@ -173,7 +173,7 @@
                                                         {% endfor %}
                                                         <a href="{% url 'member_form' membership_package.organisation_name member.id %}"><button class="btn btn-sm btn-rounded btn-light mr-1 mt-1" data-toggle="tooltip" title="Edit Member Details"><i class="fad fa-user-edit text-info"></i></button></a>
                                                         <button class="btn btn-sm btn-rounded btn-light mt-1 passRstBtnIn" value="{{ member.user_account.email }}" data-toggle="tooltip" title="Reset Password"><i class="fad fa-key text-success"></i></button>
-                                                        <button href="javascript:removeMember({{ member.id }}, incompleteMembersTable);" class="btn btn-sm btn-rounded btn-light mt-1 removeUserBtn" data-toggle="tooltip" title="Remove Member" value="{{ member.id }}"><i class="fad fa-user-slash text-danger"></i></button>
+                                                        <a href="javascript:removeMember({{ member.id }}, 'incompleteMembersTable');"><button class="btn btn-sm btn-rounded btn-light mt-1 removeUserBtn" data-toggle="tooltip" title="Remove Member" value="{{ member.id }}"><i class="fad fa-user-slash text-danger"></i></button></a>
                                                     </td>
                                                 </tr>
                                             {% empty %}
@@ -242,7 +242,7 @@
                                                                         </li>
                                                                         <!-- remove member -->
                                                                         <li>
-                                                                            <a href="javascript:removeMember({{ member.id }}, overdueMembersTable);" value="{{ member.id }}" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>
+                                                                            <a href="javascript:removeMember({{ member.id }}, 'overdueMembersTable');" value="{{ member.id }}" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>
                                                                         </li>
                                                                     </ul>
                                                                 </div>

--- a/membership/templates/membership-package.html
+++ b/membership/templates/membership-package.html
@@ -115,7 +115,7 @@
                             <div class="card-body">
                                 <h3 class="text-success">Complete Membership Applications</h3>
                                 <div class="table-responsive" style="overflow: visible;">
-                                    <table id="default_order" class="table table-striped table-bordered display no-wrap" style="width:100%">
+                                    <table id="show_hide_col" class="table table-striped table-bordered display no-wrap" style="width:100%">
                                         <thead>
                                             <tr>
                                                 <th>ID</th>
@@ -539,7 +539,7 @@
     <script>
         // create variable so that we are redirected back to this page
         var page = 'org';
-        var members_table = $('#default_order').DataTable({
+        var members_table = $('#show_hide_col').DataTable({
             "processing": true,
             "serverSide": true,
             "responsive": true,

--- a/membership/templates/membership-package.html
+++ b/membership/templates/membership-package.html
@@ -173,7 +173,7 @@
                                                         {% endfor %}
                                                         <a href="{% url 'member_form' membership_package.organisation_name member.id %}"><button class="btn btn-sm btn-rounded btn-light mr-1 mt-1" data-toggle="tooltip" title="Edit Member Details"><i class="fad fa-user-edit text-info"></i></button></a>
                                                         <button class="btn btn-sm btn-rounded btn-light mt-1 passRstBtnIn" value="{{ member.user_account.email }}" data-toggle="tooltip" title="Reset Password"><i class="fad fa-key text-success"></i></button>
-                                                        <button class="btn btn-sm btn-rounded btn-light mt-1 removeUserBtn" data-toggle="tooltip" title="Remove Member" value="{{ member.id }}"><i class="fad fa-user-slash text-danger"></i></button>
+                                                        <button href="javascript:removeMember({{ member.id }}, incompleteMembersTable);" class="btn btn-sm btn-rounded btn-light mt-1 removeUserBtn" data-toggle="tooltip" title="Remove Member" value="{{ member.id }}"><i class="fad fa-user-slash text-danger"></i></button>
                                                     </td>
                                                 </tr>
                                             {% empty %}
@@ -242,7 +242,7 @@
                                                                         </li>
                                                                         <!-- remove member -->
                                                                         <li>
-                                                                            <a href="javascript:removeMember({{ member.id }});" value="{{ member.id }}" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>
+                                                                            <a href="javascript:removeMember({{ member.id }}, overdueMembersTable);" value="{{ member.id }}" class="dropdown-item"><i class="fad fa-user-slash text-danger mr-2"></i>Remove Member</a>
                                                                         </li>
                                                                     </ul>
                                                                 </div>
@@ -570,14 +570,11 @@
 
     <script>
 
-        var removeMember = function (user_id) {
+        var removeMember = function (user_id, table_id) {
             $('#remove-member-modal').modal('show');
             $('#user-id').val(user_id);
+            $('#table-id').val(table_id);
         }
-
-        $('.removeUserBtn').on('click',function(){
-            removeMember($(this).attr("value"));
-        });
 
         var resetMemberPwd = function (user_email) {
             $.ajax({

--- a/membership/templates/membership-package.html
+++ b/membership/templates/membership-package.html
@@ -572,7 +572,7 @@
 
         var removeMember = function (user_id) {
             $('#remove-member-modal').modal('show');
-            $('#removeUserUrl').attr("href", "/membership/remove-member/{{ membership_package.organisation_name }}/" + user_id + "/?next=org_page");
+            $('#user-id').val(user_id);
         }
 
         $('.removeUserBtn').on('click',function(){

--- a/membership/templates/remove_member_modal.html
+++ b/membership/templates/remove_member_modal.html
@@ -36,9 +36,12 @@
                 if (result['status'] == "fail") {
                     errorMsg(result['message']);
                 } else {
-                    var tableId = $("#table-id").val();
-                    $('#' + tableId).DataTable().ajax.reload(null, false);
-                    //$('#show_hide_col').DataTable().ajax.reload(null, false);
+                    // if the id of the table is the id of complete members/members detailed table
+                    if($('#table-id') == 'show_hide_col') {
+                        $('#show_hide_col').DataTable().ajax.reload(null, false);
+                    } else { // if it's a normal table just reload the page
+                        location.reload();
+                    }
                     $('#remove-member-modal').modal('hide');
                 }
             }

--- a/membership/templates/remove_member_modal.html
+++ b/membership/templates/remove_member_modal.html
@@ -37,7 +37,7 @@
                     errorMsg(result['message']);
                 } else {
                     // if the id of the table is the id of complete members/members detailed table
-                    if($('#table-id') == 'show_hide_col') {
+                    if($('#table-id').val() == 'show_hide_col') {
                         $('#show_hide_col').DataTable().ajax.reload(null, false);
                     } else { // if it's a normal table just reload the page
                         location.reload();

--- a/membership/templates/remove_member_modal.html
+++ b/membership/templates/remove_member_modal.html
@@ -13,6 +13,7 @@
                 <button type="button" class="btn btn-light" data-dismiss="modal">Cancel</button>
                 <button type="button" class="btn btn-danger" id="continue">Continue</button>
                 <input id="user-id" type="hidden">
+                <input id="table-id" type="hidden">
             </div>
         </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->
@@ -35,7 +36,9 @@
                 if (result['status'] == "fail") {
                     errorMsg(result['message']);
                 } else {
-                    $('#show_hide_col').DataTable().ajax.reload(null, false);
+                    var tableId = $("#table-id").val();
+                    $('#' + tableId).DataTable().ajax.reload(null, false);
+                    //$('#show_hide_col').DataTable().ajax.reload(null, false);
                     $('#remove-member-modal').modal('hide');
                 }
             }


### PR DESCRIPTION
in membership package template the removeMember function wasn't setting the value of the hidden input to the user ID properly, so I did that fix, but then realised that the overdue and incomplete tables aren't datatables so have to be refreshed by refreshing the page, as opposed to refreshing the datatable as is done for members detailed and complete members table so that the table page isn't lost. So I had to pass in the id of the table to the remove member modal as well, and use that to know whether the table is a datatable or a normal table.