### PR TITLE
Display mem num

### DIFF
--- a/membership/templates/member_form.html
+++ b/membership/templates/member_form.html
@@ -53,6 +53,7 @@
                          {% csrf_token %}
                         <div class="card-body">
                             <h4 class="card-title">Details</h4>
+                            {% if membership_number %}<p>Expected membership number: <b>{{ membership_number }}</b></p>{% endif %}
                             <div class="row">
                                 <!-- first name field -->
                                 <div class="col-sm-12 col-lg-6">

--- a/membership/views.py
+++ b/membership/views.py
@@ -1008,6 +1008,7 @@ def member_reg_form(request, title, pk):
             # user is admin/owner create a new member
             member_id = pk
             form = MemberForm()
+            membership_number = get_next_membership_number()
         else:
             # user is not allowed to edit this member
             return redirect('dashboard')
@@ -1189,7 +1190,8 @@ def member_reg_form(request, title, pk):
                                                 'is_price_active_visible': is_price_active_visible,
                                                 'is_stripe': is_stripe,
                                                 'member_id': member_id,
-                                                'custom_fields': custom_fields_displayed})
+                                                'custom_fields': custom_fields_displayed,
+                                                'membership_number': f'{membership_number} or {None}'})
 
 
 @login_required(login_url='/accounts/login/')

--- a/membership/views.py
+++ b/membership/views.py
@@ -1183,6 +1183,11 @@ def member_reg_form(request, title, pk):
             # stripe account created but not setup
             pass
 
+    try:
+        membership_number = membership_number
+    except UnboundLocalError:
+        membership_number = None
+
     return render(request, 'member_form.html', {'user_form_fields': user_form_fields,
                                                 'form': form,
                                                 'membership_package': membership_package,
@@ -1191,7 +1196,7 @@ def member_reg_form(request, title, pk):
                                                 'is_stripe': is_stripe,
                                                 'member_id': member_id,
                                                 'custom_fields': custom_fields_displayed,
-                                                'membership_number': f'{membership_number} or {None}'})
+                                                'membership_number': membership_number})
 
 
 @login_required(login_url='/accounts/login/')


### PR DESCRIPTION
When an admin/owner adds a new member, in the member form they will see the expected membership number of the new member.
I haven't displayed expected membership number to normal users in the member form when they are adding themselves because i didn't think it would mean anything to them.
And i don't display it for members that already have a subscription which the user wants to edit