### PR TITLE
allow member to be updated if user is the member being editted, as we…

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1115,7 +1115,8 @@ def member_reg_form(request, title, pk):
                                           postcode=form.cleaned_data['postcode'],
                                           contact_number=form.cleaned_data['contact_number'])
 
-            elif (pk != 0 and request.user == membership_package.owner) or (pk != 0 and request.user in membership_package.admins.all()):
+            # if member is owner, admin, or user is member
+            elif (pk != 0 and request.user == membership_package.owner) or (pk != 0 and request.user in membership_package.admins.all())  or (pk != 0 and request.user == member.user_account):
                 # edit member
                 # validate email not already in use
                 try:
@@ -1146,8 +1147,8 @@ def member_reg_form(request, title, pk):
                     member.user_account.save()
                     
             else:
-                # new membership request but user is not admin/owner tut tut
-                redirect('dashboard')
+                # new membership request but user is not admin/owner/member being editted tut tut
+                return redirect('dashboard')
 
             try:
                 subscription = MembershipSubscription.objects.get(member=member, membership_package=membership_package)


### PR DESCRIPTION
The error was being caused by the subscription.stripe_id not existing. stripe_id is set using stripe customer. stripe customer is created in member_reg_form using member. But I found that, if pk != 0, and request.user is not owner/admin, the member is not updated. Perhaps member not being set was causing customer not being created properly which caused stripe_id to not be set properly which caused the error? So I did the following ...

Allow member to be updated if user is the member being editted, as well as if user is owner/admin.
Also corrected the redirect by putting return in front of it.
Haven't been able to test this though, due to another problem I ran into where I was getting the ValueError 'dictionary update sequence element #0 has length 1; 2 is required' on the line 'for key, custom_field in dict(custom_fields_displayed).items():' when submitting member form when not owner/admin