### PR TITLE
handle when expiry not input in member form

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1165,9 +1165,14 @@ def member_reg_form(request, title, pk):
             # additional fields
             subscription.gift_aid = form.cleaned_data['gift_aid']
             subscription.comments = form.cleaned_data['comments']
-            print(form.cleaned_data['membership_expiry'])
-            membership_expiry = datetime.strptime(form.cleaned_data['membership_expiry'], '%d/%m/%Y')
-            subscription.membership_expiry = membership_expiry.strftime('%Y-%m-%d')
+
+            # default expiry to None if not set, as it will be set in the handling of the payment page
+            if form.cleaned_data['membership_expiry']:
+                membership_expiry = datetime.strptime(form.cleaned_data['membership_expiry'], '%d/%m/%Y')
+                subscription.membership_expiry = membership_expiry.strftime('%Y-%m-%d')
+            else:
+                membership_expiry = None
+                subscription.membership_expiry = membership_expiry
 
             # create/ update stripe customer
             stripe.api_key = get_stripe_secret_key(request)
@@ -1470,7 +1475,6 @@ class MemberPaymentView(LoginRequiredMixin, MembershipBase):
                     # default remaining amount to old price amount if not set
                     if not subscription.remaining_amount:
                         subscription.remaining_amount = old_price.amount
-                    print(f'1408 - {subscription.membership_expiry}')
                     # default membership_expiry, if not set, to next renewal date in the future/present
                     if not subscription.membership_expiry:
                         if old_interval:
@@ -1486,7 +1490,6 @@ class MemberPaymentView(LoginRequiredMixin, MembershipBase):
                     # increment expiry
                     else:
                         subscription.membership_expiry = subscription.membership_expiry + new_interval
-                    print(f'1421 - {subscription.membership_expiry}')
                     # if previous membership type was not one_time
                     if int(subscription.remaining_amount) != 0:
                         # set new remaining amount, taking off the amount paid from new amount
@@ -1495,8 +1498,6 @@ class MemberPaymentView(LoginRequiredMixin, MembershipBase):
                     # previous membership type was one_time, so default to new price amount
                     else:
                         subscription.remaining_amount = subscription.price.amount
-                    print(f'rem amount 1430 - {subscription.remaining_amount}')
-                    print(f'1431 - {subscription.membership_expiry}')
                     # if fully paid, reset remaining amount and increment membership_expiry
                     # or if amount paid is more than new price amount, keep incrementing expiry until user isn't owed anything
                     while int(subscription.remaining_amount) <= 0:
@@ -1504,7 +1505,6 @@ class MemberPaymentView(LoginRequiredMixin, MembershipBase):
                         subscription.membership_expiry = subscription.membership_expiry + new_interval
                         # add new price to remaining amount
                         subscription.remaining_amount = int(subscription.remaining_amount) + int(subscription.price.amount)
-                    print(f'1438 - {subscription.membership_expiry}')
                 except Price.DoesNotExist:
                     pass
 


### PR DESCRIPTION
handle if expiry has not been input in the member form (which will be the case unless user is superuser, as the field is hidden)