### PR TITLE
Added payment defect

### DIFF
--- a/membership/tabledata.py
+++ b/membership/tabledata.py
@@ -582,7 +582,7 @@ def get_member_payments(request, title, pk=None):
                                             <a href="javascript:deletePayment({member.id}, {payment.id});"><button class="btn btn-sm btn-rounded btn-light mr-1 mt-1" data-toggle="tooltip" title="Delete Payment"><i class="fad fa-trash-alt text-danger"></i></button></a>""",
                              'id': payment.payment_number,
                              'method': method,
-                             'type': payment.type,
+                             'type': str(payment.type).title(),
                              'amount': "£%.2f" % temp_amount,
                              'comments': payment.comments,
                              'created': str(payment.created),

--- a/membership/views.py
+++ b/membership/views.py
@@ -2030,13 +2030,13 @@ def member_payment_form(request, title, pk):
             payment.save()
 
             # if payment is a subscription payment
-            if payment.type == 'subscription':
+            if payment.type in ('subscription', 'Subscription'):
                 # if subscription is recurring
-                if subscription.price.interval != 'one_time':
+                if subscription.price.interval not in ('one_time', 'One Time'):
                     # set amount of time to increment
-                    if subscription.price.interval == 'year':
+                    if subscription.price.interval in ('year', 'Yearly'):
                         interval = relativedelta(years=1)
-                    elif subscription.price.interval == 'month':
+                    elif subscription.price.interval in ('month', 'Monthly'):
                         interval = relativedelta(months=1)
 
                     # default membership_expiry, if not set, to next renewal date in the future/present


### PR DESCRIPTION
used title() to display payment type with a capital letter at the start.
used tuples so the handling of the add payment form can handle payment types and intervals that are in the format to be displayed to the user, just in case that was causing the defect SHS found where a member is still overdue even after a payment was added, but I suspect the real reason is that the expiry started off too far in the past, and it incremented, but is still in the past.