### PR TITLE
deleted the old datepicker javascript

### DIFF
--- a/membership/templates/payment_form.html
+++ b/membership/templates/payment_form.html
@@ -196,16 +196,6 @@
 </div>
 {% endblock %}
 {% block footer %}
-    <script src="{% static 'assets/libs/moment/moment.js' %}"></script>
-    <script src="{% static 'assets/libs/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js' %}"></script>
-    <script>
-        // Date Picker
-        jQuery('.datepicker').datepicker({
-            autoclose: true,
-            todayHighlight: true
-        });
-    </script>
-
     <script>
         // Set amount to subscription amount if type set to subscription
         $('#type').change(function(e){
@@ -239,6 +229,7 @@
             }
         });
     </script>
+    <script src="{% static 'assets/libs/moment/moment.js' %}"></script>
     <script src="{% static 'assets/libs/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js' %}"></script>
     <script>
         // Date Picker


### PR DESCRIPTION
when you fixed the date widget for the payment form (to add a payment) you forgot to remove the old code, so it was still using the old javascript. I removed it and added the moment script to above your new code.