### PR TITLE
display zero pounds remaining if member not overdue

### DIFF
--- a/membership/templates/member_payments.html
+++ b/membership/templates/member_payments.html
@@ -72,10 +72,15 @@
                 <div class="col b-r float-right"> <strong>Remaining Amount</strong>
                     <br>
                     <p class="text-muted">
-                        {% if subscription.remaining_amount %}
-                            £{{ subscription.remaining_amount|price }}
+                        {% if overdue %}
+                            {% if subscription.remaining_amount %}
+                                £{{ subscription.remaining_amount|price }}
+                            {% else %}
+                                £{{ subscription.price.amount|price }}
+                            {% endif %}
+                        <!-- display £0 remaining if not overdue -->
                         {% else %}
-                            £{{ subscription.price.amount|price }}
+                            £0
                         {% endif %}
                     </p>
                 </div>


### PR DESCRIPTION
adam suggested that it would be better to display 0 pounds remaining if the member is not overdue, as seeing remaining money to be spent for a subscription payment in the future when not overdue might be miss leading