### PR TITLE
invisible custom fields were being lost

### DIFF
--- a/membership/views.py
+++ b/membership/views.py
@@ -1028,7 +1028,8 @@ def member_reg_form(request, title, pk):
             custom_fields = None
 
     # if user is not owner/admin, remove invisible custom fields
-    custom_fields_displayed = custom_fields
+    custom_fields_displayed = dumps(custom_fields)
+    custom_fields_displayed = loads(custom_fields_displayed)
     if custom_fields:
         if request.user != membership_package.owner and request.user not in membership_package.admins.all():
             # iterate through each custom field dictionary


### PR DESCRIPTION
custom_fields was also changing when the invisible field was removed from custom_fields_displayed. I changed it to use dumps and loads and now custom_fields doesn't change, so the defect where a new subscription didn't have the invisible custom fields is now fixed