### PR TITLE
Update without payment

### DIFF
--- a/membership/models.py
+++ b/membership/models.py
@@ -93,6 +93,7 @@ class MembershipSubscription(models.Model):
     price = models.ForeignKey(Price, on_delete=models.CASCADE, blank=True, null=True, related_name='price', verbose_name="Price")
     stripe_id = models.CharField(max_length=255, blank=True)
     stripe_subscription_id = models.CharField(max_length=255, blank=True)
+    stripe_schedule_id = models.CharField(max_length=255, blank=True)
     validated = models.BooleanField(default=False)
     comments = models.TextField(blank=True)
     membership_start = models.DateField(null=True, blank=True, default=datetime.now)

--- a/membership/templates/member_profile.html
+++ b/membership/templates/member_profile.html
@@ -658,16 +658,16 @@
         }
 
         function stripeTokenHandler(token) {
-            // url 'member_payment' package.organisation_name member.id
-            memberPaymentUrl = '/membership/member-payment/' + $("#orgPaymentSelection option:selected" ).text() + '/' + '{{ member.id }}';
             // Submit the token
             $.ajax({
-                url: memberPaymentUrl,
+                url: "{% url 'create_stripe_subscription' %}",
                 type: 'post',
                 dataType: 'text',
                 headers: {'X-CSRFToken': '{{ csrf_token }}'},
                 data: {
                     'token': token,
+                    'org_name': $("#orgPaymentSelection option:selected" ).text(),// package.organisation_name
+                    'member_id': '{{ member.id }}'// member.id
                     },
                 beforeSend: function() {
                     $('#paymentSuccess').addClass('d-none');

--- a/membership/templates/member_profile.html
+++ b/membership/templates/member_profile.html
@@ -9,11 +9,7 @@
 
 {% block content %}
 
-{% if customer %}
-    {% include 'spinner-overlay.html' with msg='Updating Member Card...' %}
-{% else %}
-    {% include 'spinner-overlay.html' with msg='Creating Member Payment...' %}
-{% endif %}
+{% include 'spinner-overlay.html' with msg='Updating Member Card...' %}
 
 <!-- ============================================================== -->
 <!-- Bread crumb and right sidebar toggle -->
@@ -318,6 +314,12 @@
                                             <li><i class="fad fa-chevron-right"></i> Area Code: {{ customer.sources.data.0.address_zip }}</li>
                                         </ul>
                                     {% endif %}
+                                </div>
+                            </div>
+                            <!-- if no stripe subscription, tell them updating card will create one -->
+                            <div class="row mt-4">
+                                <div class="col-12">
+                                    <p>Keeping your card up to date allows your subscription payments to happen automatically each time they are due.</p>
                                 </div>
                             </div>
                             <hr>

--- a/membership/urls.py
+++ b/membership/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('export_payments_detailed/<str:title>', reports.export_payments_detailed, name="export_payments_detailed"),
     path('organisation-payment', views.organisation_payment, name='organisation_payment'),
     path('create-package-on-stripe', views.create_package_on_stripe, name='create_package_on_stripe'),
+    path('create_stripe_subscription', views.create_stripe_subscription, name='create_stripe_subscription'),
     path('membership-package-settings', views.CreateMembershipPackage.as_view(), name="membership_package_settings"),
     path('members-detailed/<str:title>', views.MembersDetailed.as_view(), name="members_detailed"),
     path('delete-payment/<str:title>/<int:pk>/<int:payment_id>/', views.delete_payment, name="delete_payment"),

--- a/membership/views.py
+++ b/membership/views.py
@@ -718,6 +718,13 @@ def create_stripe_subscription(request):
     package = MembershipPackage.objects.get(organisation_name=request.POST.get('org_name'))
     member = Member.objects.get(id=request.POST.get('member_id'))
     subscription = MembershipSubscription.objects.get(member=member, membership_package=package)
+
+    # validate card
+    result = validate_card(request, 'member', subscription)
+    if result['result'] == 'fail':
+        return HttpResponse(dumps(result))
+
+    # set payment method
     
     # create stripe subscription if price is recurring
     if subscription.price.interval != 'one_time':

--- a/membership/views.py
+++ b/membership/views.py
@@ -1781,7 +1781,7 @@ def update_membership_type(request, title, pk):
                 subscription.stripe_subscription_id = ''
             # cancel stripe subscription schedule
             if subscription.stripe_schedule_id:
-                stripe.SubscriptionSchedule.delete(subscription.stripe_schedule_id,
+                stripe.SubscriptionSchedule.cancel(subscription.stripe_schedule_id,
                                         stripe_account=package.stripe_acct_id)
                 subscription.stripe_schedule_id = ''
                 
@@ -2435,7 +2435,7 @@ def remove_member(request, title):
                                     stripe_account=membership_package.stripe_acct_id)
         # cancel subscription schedule
         if subscription.stripe_schedule_id:
-            stripe.SubscriptionSchedule.delete(subscription.stripe_schedule_id,
+            stripe.SubscriptionSchedule.cancel(subscription.stripe_schedule_id,
                                     stripe_account=membership_package.stripe_acct_id)
 
         # delete customer from stripe account

--- a/membership/views.py
+++ b/membership/views.py
@@ -797,8 +797,12 @@ def create_stripe_subscription(request):
                     stripe_account=package.stripe_acct_id,
                 )
             
-            # set subscription ID to match new subscription
-            subscription.stripe_subscription_id = subscription_details.id
+            if subscription_details['object'] == 'subscription':
+                # set subscription ID to match new subscription
+                subscription.stripe_subscription_id = subscription_details.id
+            elif subscription_details['object'] == 'subscription_schedule':
+                # set schedule ID to match new schedule
+                subscription.stripe_schedule_id = subscription_details.id
             
             # fail if didn't work
             if subscription_details['status'] != 'active' and subscription_details['object'] != 'subscription_schedule':

--- a/membership/views.py
+++ b/membership/views.py
@@ -725,6 +725,9 @@ def create_stripe_subscription(request):
         return HttpResponse(dumps(result))
 
     # set payment method
+    if subscription.payment_method:
+        subscription.payment_method = None
+        subscription.save()
     
     # create stripe subscription if price is recurring
     if subscription.price.interval != 'one_time':

--- a/membership/views.py
+++ b/membership/views.py
@@ -726,8 +726,8 @@ def create_stripe_subscription(request):
     
     # create stripe subscription if price is recurring
     if subscription.price.interval != 'one_time':
-        # if user doesn't have stripe subscription, make one
-        if not subscription.stripe_subscription_id:
+        # if user doesn't have stripe subscription or schedule, make one
+        if not subscription.stripe_subscription_id and not subscription.stripe_schedule_id:
             # if the subscription has a value for expiry date
             if subscription.membership_expiry:
                 # start date of subscription

--- a/membership/views.py
+++ b/membership/views.py
@@ -736,7 +736,6 @@ def create_stripe_subscription(request):
                 # if their next interval to be paid for is partially paid for
                 if subscription.remaining_amount:
                     if int(subscription.remaining_amount) < int(subscription.price.amount):
-                        print('increment start')
                         # increment start date by one interval
                         if subscription.price.interval == 'year':
                             sub_start = sub_start + relativedelta(years=1)
@@ -745,7 +744,6 @@ def create_stripe_subscription(request):
                 
                 # if sub start date is in the past
                 if sub_start < datetime.now().date():
-                    print('backdate')
                     # create subscription backdated to next payment due that is in the past
                     subscription_details = stripe.Subscription.create(
                         customer=subscription.stripe_id,
@@ -759,7 +757,6 @@ def create_stripe_subscription(request):
                     )
                 # if sub start is in the future
                 else:
-                    print('forward-date')
                     # create subscription forward-dated to next payment due that is in the future
                     subscription_details = stripe.Subscription.create(
                         customer=subscription.stripe_id,
@@ -773,7 +770,6 @@ def create_stripe_subscription(request):
                     )
             # there is no value for expiry date so start the subscription from today
             else:
-                print('no expiry')
                 # create subscription starting from now
                 subscription_details = stripe.Subscription.create(
                     customer=subscription.stripe_id,

--- a/membership/views.py
+++ b/membership/views.py
@@ -1779,6 +1779,11 @@ def update_membership_type(request, title, pk):
                 stripe.Subscription.delete(subscription.stripe_subscription_id,
                                         stripe_account=package.stripe_acct_id)
                 subscription.stripe_subscription_id = ''
+            # cancel stripe subscription schedule
+            if subscription.stripe_schedule_id:
+                stripe.SubscriptionSchedule.delete(subscription.stripe_schedule_id,
+                                        stripe_account=package.stripe_acct_id)
+                subscription.stripe_schedule_id = ''
                 
             subscription.save()
                 
@@ -2427,6 +2432,10 @@ def remove_member(request, title):
         # cancel subscription
         if subscription.stripe_subscription_id:
             stripe.Subscription.delete(subscription.stripe_subscription_id,
+                                    stripe_account=membership_package.stripe_acct_id)
+        # cancel subscription schedule
+        if subscription.stripe_schedule_id:
+            stripe.SubscriptionSchedule.delete(subscription.stripe_schedule_id,
                                     stripe_account=membership_package.stripe_acct_id)
 
         # delete customer from stripe account

--- a/membership/views.py
+++ b/membership/views.py
@@ -820,13 +820,6 @@ def create_stripe_subscription(request):
             subscription.payment_method = None
             
         subscription.save()
-    else:
-        # fail if subscription is one time
-        result = {
-            'result': 'fail',
-            'feedback': "<strong>Failure message:</strong> <span class='text-danger'>Your subscription uses a one time payment, so no card details are required.</span>"
-        }
-        return HttpResponse(dumps(result))
     
     result = {
         'result': 'success'

--- a/membership/views.py
+++ b/membership/views.py
@@ -745,6 +745,12 @@ def create_stripe_subscription(request):
             'result': 'success'
         }
         return HttpResponse(dumps(result))
+    else:
+        result = {
+            'result': 'fail',
+            'feedback': "<strong>Failure message:</strong> <span class='text-danger'>Your subscription uses a one time payment, so no card details are required.</span>"
+        }
+        return HttpResponse(dumps(result))
 
 
 @login_required(login_url='/accounts/login/')

--- a/membership/views.py
+++ b/membership/views.py
@@ -766,7 +766,8 @@ def create_stripe_subscription(request):
                             },
                         ],
                         stripe_account=package.stripe_acct_id,
-                        billing_cycle_anchor=int(datetime.combine(sub_start, datetime.min.time()).timestamp())
+                        billing_cycle_anchor=int(datetime.combine(sub_start, datetime.min.time()).timestamp()),
+                        proration_behavior='none'
                     )
                 # expires today
                 else:


### PR DESCRIPTION
MIGRATE - added stripe_schedule_id to MembershipSubscription
prevented "payment made" spinner from ever showing, instead it's just "updating card" now
added descriptive line above card details form
made new function create_stripe_subscription which updates the card and then makes an appropriate subscription, or subscription schedule, if needed
in 2 places, when a stripe subscription is cancelled, I also cancel the stripe schedule in case one has been made